### PR TITLE
CMake Subproject Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT hasParent)
     include(pico_sdk_import.cmake)
 endif()
 
-project(waveshare-pico-10dof-imu_project)
+project(waveshare_pico_10dof_imu)
 
 if(NOT hasParent)
     pico_sdk_init()
@@ -22,6 +22,9 @@ target_link_libraries(lps22hb PUBLIC hardware_i2c pico_stdlib)
 add_library(icm20948 src/icm20948/icm20948.c)
 target_include_directories(icm20948 PRIVATE include)
 target_link_libraries(icm20948 PUBLIC hardware_i2c pico_stdlib)
+
+set(${PROJECT_NAME}_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/include
+    CACHE INTERNAL "${PROJECT_NAME}: Include Directories" FORCE)
 
 # main
 add_executable(imu src/main.c)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,36 @@
 # Waveshare Pico-10DOF-IMU
 
 This is a repo for the [Pico-10DOF-IMU](https://www.waveshare.com/wiki/Pico-10DOF-IMU). I have refactored the code provided by waveshare from the archive provided at the wiki to conform to C++ and cmake project standards.
+
+## Building
+
+The [pico-sdk](https://github.com/raspberrypi/pico-sdk) needs to be cloned locally first.
+### Standalone
+```bash
+mkdir -p build && cd $_
+PICO_SDK_PATH=/path/to/pico-sdk cmake ..
+# alternatively the above command can be split into two if PICO_SDK_PATH is exported as an env var first with export PICO_SDK_PATH=...
+make -j4
+```
+
+### As a Subproject
+
+First, make sure that the following `add_subdirectory` func call is inside either the root `CMakeLists.txt` or within an intermediate project's `CMakeLists.txt`.
+
+```cmake
+add_subdirectory("path/to/waveshare_pico_10dof_imu") # this is the relative path to waveshare_pico_10dof_imu from the CMakeLists.txt this call is added to
+```
+Next, add the following to each executable that is being built that uses waveshare_pico_10dof_imu.
+```cmake
+target_include_directories(my_executable
+  PRIVATE
+  ${waveshare_pico_10dof_imu_INCLUDE_DIRS}
+  # other headers that are used go here too
+)
+
+target_link_libraries(
+  my_executable
+  pico_stdlib icm20948 lps22hb hardware_i2c
+  # other libraries that are used go here too
+)
+```


### PR DESCRIPTION
- Project's headers exposed for use as subproject
- README includes building examples, standalone and subproject